### PR TITLE
Found a Web site hosting these tutorials, want to add a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 **[[Submit tutorial](https://github.com/danistefanovic/build-your-own-x/issues/new)]**
 
+[Web version here!](http://www.byo-x.org/contents)
+
 # ![Build your own X](feynman.png)
 
 ## Table of contents


### PR DESCRIPTION
Found a Web site hosting these tutorials on their page, as a 'Web version': www.byo-x.org with a link back to here.

Originally found: on [this rant](https://devrant.com/rants/1511286/hey-devrant-here-is-a-list-with-some-dev-tutorials-currently-208-more-are-being).

Just a thought that you might want to include it on your page for anyone interested in using it!