### PR TITLE
Fixed 404, for Neural Net from Scratch in Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@
 * [**F#**: _Building Neural Networks in F#_](https://towardsdatascience.com/building-neural-networks-in-f-part-1-a2832ae972e6)
 * [**Go**: _Build a multilayer perceptron with Golang_](https://made2591.github.io/posts/neuralnetwork)
 * [**Go**: _How to build a simple artificial neural network with Go_](https://sausheong.github.io/posts/how-to-build-a-simple-artificial-neural-network-with-go/)
-* [**Go**: _Building a Neural Net from Scratch in Go_](https://www.datadan.io/building-a-neural-net-from-scratch-in-go/)
+* [**Go**: _Building a Neural Net from Scratch in Go_](https://datadan.io/neural-net-with-go)
 * [**JavaScript / Java**: _Neural Networks - The Nature of Code_](https://www.youtube.com/playlist?list=PLRqwX-V7Uu6aCibgK1PTWWu9by6XFdCfh) [video]
 * [**JavaScript**: _Neural Network implementation in JavaScript, by an example_](https://franpapers.com/en/machine-learning-ai-en/2017-neural-network-implementation-in-javascript-by-an-example/)
 * [**JavaScript**: _Neural networks from scratch for JavaScript linguists (Part1 — The Perceptron)_](https://hackernoon.com/neural-networks-from-scratch-for-javascript-linguists-part1-the-perceptron-632a4d1fbad2)


### PR DESCRIPTION
Updated URL for [**Building a Neural Net from Scratch in Go**](https://github.com/danistefanovic/build-your-own-x#build-your-own-neural-network). The author of that blog **updated the address**, so the previous URL was getting a **404**. Added the correct address,

from https://datadan.io/building-a-neural-net-from-scratch-in-go
to https://datadan.io/neural-net-with-go