### PR TITLE
Fix URL of Roguelike Tutorial Revised

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@
 * [**Python**: _Developing Games With PyGame_](https://pythonprogramming.net/pygame-python-3-part-1-intro/)
 * [**Python**: _Making Games with Python & Pygame_](https://inventwithpython.com/makinggames.pdf) [pdf]
 * [**Python**: _The Complete Roguelike Tutorial_](https://www.youtube.com/playlist?list=PLKUel_nHsTQ1yX7tQxR_SQRdcOFyXfNAb) [video]
-* [**Python**: _Roguelike Tutorial Revised_](http://rogueliketutorials.com/libtcod/1)
+* [**Python**: _Roguelike Tutorial Revised_](http://rogueliketutorials.com/)
 * [**Ruby**: _Developing Games With Ruby_](https://leanpub.com/developing-games-with-ruby/read)
 * [**Ruby**: _Ruby Snake_](https://www.diatomenterprises.com/gamedev-on-ruby-why-not/)
 * [**Rust**: _Adventures in Rust: A Basic 2D Game_](https://a5huynh.github.io/2018/02/02/adventures-in-rust.html)


### PR DESCRIPTION
The URL for *Python: Roguelike Tutorial Revised* is wrong as it leads to a `404 Not Found` page. I fix it with the correct URL.