### PR TITLE
Change EvolutionaryTetrisAI link to original author

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@
 * [**JavaScript**: _Implementing promises from scratch (TDD way)_](https://www.mauriciopoppe.com/notes/computer-science/computation/promises/)
 * [**JavaScript**: _Implement your own — call(), apply() and bind() method in JavaScript_](https://blog.usejournal.com/implement-your-own-call-apply-and-bind-method-in-javascript-42cc85dba1b)
 * [**JavaScript**: _JavaScript Algorithms and Data Structures_](https://github.com/trekhleb/javascript-algorithms)
-* [**JavaScript**: _How to Make an Evolutionary Tetris AI_](https://www.youtube.com/watch?v=xLHCMMGuN0Q) [video]
+* [**JavaScript**: _How to Make an Evolutionary Tetris AI_](https://idreesinc.com/about-tetnet.html)
 * [**JavaScript**: _Build a ride hailing app with React Native_](https://pusher.com/tutorials/ride-hailing-react-native)
 * [**Kotlin**: _Build Your Own Cache_](https://github.com/kezhenxu94/cache-lite)
 * [**Nim**: _Writing a Redis Protocol Parser_](https://xmonader.github.io/nimdays/day12_resp.html)


### PR DESCRIPTION
In the *Uncategorized* section, The link **JavaScript: How to Make an Evolutionary Tetris AI [video]** takes you to https://www.youtube.com/watch?v=xLHCMMGuN0Q. Unfortunately, the creator of the video claimed to have made the code from scratch when in reality it was stolen. It is clear that in the video, the author does not fully understand the code he is teaching in the video, and worse he is claiming it as his own.

The original source code can be found [here](https://github.com/IdreesInc/TetNet/blob/master/tetnet.js). That same original author created a tutorial page dedicated to explaining how to create the AI in his own site found [here](https://idreesinc.com/about-tetnet.html).

 I feel like this link is a stain on an otherwise magnificent repository. Please consider switching the links.