### PR TITLE
Add Haskell entry for Neural Networks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ This repository is a compilation of well-written, step-by-step guides for re-cre
 * [**Go**: _Build a multilayer perceptron with Golang_](https://made2591.github.io/posts/neuralnetwork)
 * [**Go**: _How to build a simple artificial neural network with Go_](https://sausheong.github.io/posts/how-to-build-a-simple-artificial-neural-network-with-go/)
 * [**Go**: _Building a Neural Net from Scratch in Go_](https://datadan.io/blog/neural-net-with-go)
+* [**Haskell**: _Practical Dependent Types in Haskell: Type-Safe Neural Networks (Part 1)_](https://blog.jle.im/entry/practical-dependent-types-in-haskell-1.html)
 * [**JavaScript / Java**: _Neural Networks - The Nature of Code_](https://www.youtube.com/playlist?list=PLRqwX-V7Uu6aCibgK1PTWWu9by6XFdCfh) [video]
 * [**JavaScript**: _Neural networks from scratch for JavaScript linguists (Part1 — The Perceptron)_](https://hackernoon.com/neural-networks-from-scratch-for-javascript-linguists-part1-the-perceptron-632a4d1fbad2)
 * [**Python**: _A Neural Network in 11 lines of Python_](https://iamtrask.github.io/2015/07/12/basic-python-network/)


### PR DESCRIPTION
### Haskell

### Practical Dependent Types in Haskell: Type-Safe Neural Networks (Part 1)

### [https://blog.jle.im/entry/practical-dependent-types-in-haskell-1.html]()

### Category
* [ ] 3D Renderer
* [ ] Augmented Reality
* [ ] BitTorrent Client
* [ ] Blockchain / Cryptocurrency
* [ ] Bot
* [ ] Command-Line Tool
* [ ] Database
* [ ] Docker
* [ ] Emulator / Virtual Machine
* [ ] Front-end Framework / Library
* [ ] Game
* [ ] Git
* [ ] Network Stack
* [x] Neural Network
* [ ] Operating System
* [ ] Physics Engine
* [ ] Programming Language
* [ ] Regex Engine
* [ ] Search Engine
* [ ] Shell
* [ ] Template Engine
* [ ] Visual Recognition System
* [ ] Voxel Engine
* [ ] Web Search Engine
* [ ] Web Server
* [ ] Uncategorized

---

I'd like to note that although this entry requires more than an elementary level of understanding of Haskell, it is useful for those who feel stuck in the endless Haskell intermediate level.