### PR TITLE
📦 Add linkcheck action

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -14,3 +14,5 @@ jobs:
         with:
           whitelist_files: "codecrafters-banner.png"
           whitelist_links: "https://simjue.pages.dev/post/2018/07-01-go-unix-shell/,https://www.jamasoftware.com/blog/lets-write-redux/,https://learnopengl.com/In-Practice/2D-Game/Breakout,https://www.sohamkamani.com/nodejs/telegram-bot/,https://sj14.gitlab.io/post/2018-07-01-go-unix-shell/,https://www.datacamp.com"
+        env:
+          TOKEN: ${{ secrets.TOKEN }}


### PR DESCRIPTION
In this PR, I have added a workflow which checks links and fails if any of them are broken.

Disclaimer: this action is my own, the repo is [here](https://github.com/TechWiz-3/linksafe/tree/fast).

Because of the large volume of links, I'm using the 'fast' version/branch which simply requires a GitHub token (with no extra perms) to be stored as a repo secret under the name  `TOKEN`. This is for requests to the GitHub API to avoid rate-limits. More setup info [here](https://github.com/TechWiz-3/linksafe/tree/fast#setup)

You can view the logs of the workflow on my fork [here](
https://github.com/TechWiz-3/build-your-own-x/actions/runs/3241126269/jobs/5312678033). **2** links were found to be broken.

Let me know if you'd like me to change anything, any feedback is appreciated either way :)


<img width="404" alt="Screen Shot 2022-10-13 at 9 06 56 pm" src="https://user-images.githubusercontent.com/75515581/195568636-b5684255-c18f-46ec-8b73-1abd18a2b44a.png">