### PR TITLE
docs: docs: pluralize 'Command-Line Tool' heading in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ It's a great way to learn.
 * [**R**: _Build A Cryptocurrency Trading Bot with R_](https://towardsdatascience.com/build-a-cryptocurrency-trading-bot-with-r-1445c429e1b1)
 * [**Rust**: _A bot for Starcraft in Rust, C or any other language_](https://habr.com/en/post/436254/)
 
-#### Build your own `Command-Line Tool`
+#### Build your own `Command-Line Tools`
 
 * [**Go**: _Visualize your local git contributions with Go_](https://flaviocopes.com/go-git-contributions/)
 * [**Go**: _Build a command line app with Go: lolcat_](https://flaviocopes.com/go-tutorial-lolcat/)


### PR DESCRIPTION
- Updated heading from "Command-Line Tool" to "Command-Line Tools" for consistency across categories in the README.
