### PR TITLE
Add Table of Contents heading + Back to Top link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository is a compilation of well-written, step-by-step guides for re-cre
 > *What I cannot create, I do not understand — Richard Feynman.*
 
 It's a great way to learn.
+## 📌 Table of Contents
 
 * [3D Renderer](#build-your-own-3d-renderer)
 * [Augmented Reality](#build-your-own-augmented-reality)
@@ -39,6 +40,10 @@ It's a great way to learn.
 ## Tutorials
 
 #### Build your own `3D Renderer`
+...
+[🔝 Back to top](#table-of-contents)
+
+
 
 * [**C++**: _Introduction to Ray Tracing: a Simple Method for Creating 3D Images_](https://www.scratchapixel.com/lessons/3d-basic-rendering/introduction-to-ray-tracing/how-does-it-work)
 * [**C++**: _How OpenGL works: software rendering in 500 lines of code_](https://github.com/ssloy/tinyrenderer/wiki)
@@ -480,3 +485,4 @@ It's a great way to learn.
 [![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 This repository is the work of [many contributors](https://github.com/codecrafters-io/build-your-own-x/graphs/contributors). It was started by [Daniel Stefanovic](https://github.com/danistefanovic), and is now maintained by [CodeCrafters, Inc.](https://codecrafters.io) To the extent possible under law, [CodeCrafters, Inc.](https://codecrafters.io) has waived all copyright and related or neighboring rights to this work.
+[🔝 Back to top](#table-of-contents)


### PR DESCRIPTION
The README is very large and includes many categories (AI, Blockchain, Database, etc.).  Added a clear "Table of Contents" heading near the top so readers immediately understand that the list is navigational.

Also added a "Back to Top" link at the end of the README to make scrolling easier.

This improves usability for users browsing the long README and addresses issue #1599.