### PR TITLE
docs: fix placeholder formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 [![Banner](https://codecrafters.io/images/updated-byox-banner.gif)](https://codecrafters.io/github-banner)
 
-## Build your own &lt;insert-technology-here&gt;
+## Build your own `<insert-technology-here>`
+
 
 This repository is a compilation of well-written, step-by-step guides for re-creating our favorite technologies from scratch. 
 
 > *What I cannot create, I do not understand — Richard Feynman.*
-
-It's a great way to learn.
+>
+> It's a great way to learn.
 
 * [3D Renderer](#build-your-own-3d-renderer)
 * [Augmented Reality](#build-your-own-augmented-reality)


### PR DESCRIPTION
This PR updates the section heading:

## Build your own &lt;insert-technology-here&gt;

and replaces the HTML escape codes with proper Markdown backticks:

## Build your own `<insert-technology-here>`

This improves readability and ensures the placeholder renders correctly in Markdown.
