### PR TITLE
Add ChatGPT clone tutorial under Python neural network resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,11 @@ It's a great way to learn.
 * [**Python**: _Generate Music using LSTM Neural Network in Keras_](https://towardsdatascience.com/how-to-generate-music-using-a-lstm-neural-network-in-keras-68786834d4c5)
 * [**Python**: _An Introduction to Convolutional Neural Networks_](https://victorzhou.com/blog/intro-to-cnns-part-1/)
 * [**Python**: _Neural Networks: Zero to Hero_](https://www.youtube.com/playlist?list=PLAqhIrjkxbuWI23v9cThsA9GvCAUhRvKZ)
+* [**Python**] Build your own ChatGPT with Python — freeCodeCamp (https://www.freecodecamp.org/news/build-a-chatgpt-clone-with-python/)
+
+
+
+
 
 #### Build your own `Operating System`
 


### PR DESCRIPTION
Adds a Python tutorial for building a ChatGPT-style model under the Neural Network section, offering beginners a clear and practical introduction to LLM fundamentals.