### PR TITLE
Fix broken banner image URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Banner](https://codecrafters.io/images/new-ccgithub-banner.png)](https://codecrafters.io/github-banner)
+[![Banner](https://codecrafters.io/images/updated-byox-banner.gif)](https://codecrafters.io/github-banner)
 
 ## Build your own &lt;insert-technology-here&gt;
 


### PR DESCRIPTION
## Summary
- The banner image (`new-ccgithub-banner.png`) returns a 404
- Updated to the current working image (`updated-byox-banner.gif`)

## Test plan
- [x] Verified old URL returns HTTP 404
- [x] Verified new URL returns HTTP 200
- [x] Confirm banner renders correctly in README preview