### PR TITLE
Update C# Neural Network OCR link to archived version

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ It's a great way to learn.
 
 #### Build your own `Neural Network`
 
-* [**C#**: _Neural Network OCR_](https://www.codeproject.com/Articles/11285/Neural-Network-OCR)
+* [**C#**: _Neural Network OCR_](https://web.archive.org/https://www.codeproject.com/Articles/11285/Neural-Network-OCR)
 * [**F#**: _Building Neural Networks in F#: Part 1_](https://medium.com/data-science/building-neural-networks-in-f-part-1-a2832ae972e6)
 * [**F#**: _Building Neural Networks in F#: Part 2_](https://medium.com/data-science/building-neural-networks-in-f-part-2-training-evaluation-5e3a68889da6)
 * [**Go**: _Build a multilayer perceptron with Golang_](https://made2591.github.io/posts/neuralnetwork)


### PR DESCRIPTION
This PR fixes the broken link for Neural Network OCR in the Build Your Own Neural Network section by replacing it with an archived working version.