### PR TITLE
Fix broken link in Template Engine section

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ It's a great way to learn.
 * [**JavaScript**: _Understanding JavaScript Micro-Templating_](https://medium.com/wdstack/understanding-javascript-micro-templating-f37a37b3b40e)
 * [**Python**: _Approach: Building a toy template engine in Python_](http://alexmic.net/building-a-template-engine/)
 * [**Python**: _A Template Engine_](http://aosabook.org/en/500L/a-template-engine.html)
-* [**Ruby**: _How to write a template engine in less than 30 lines of code_](http://bits.citrusbyte.com/how-to-write-a-template-library/)
+* [**Ruby**: _How to write a template engine in less than 30 lines of code_](https://web.archive.org/web/20180913134144/http://bits.citrusbyte.com/how-to-write-a-template-library/)
 
 #### Build your own `Text Editor`
 


### PR DESCRIPTION
The link to the Ruby template engine tutorial (citrusbyte.com) has an expired SSL certificate and is no longer accessible. The original domain (bits.citrusbyte.com) was migrated to bits.theorem.co, but the content is no longer available there either.

Replaced with the Wayback Machine archived version so the tutorial remains accessible.

**Before:** http://bits.citrusbyte.com/how-to-write-a-template-library/ (❌ SSL expired)
**After:** https://web.archive.org/web/20180913134144/http://bits.citrusbyte.com/how-to-write-a-template-library/ (✅ Working)
