### PR TITLE
fix: correct AI Model TOC anchor and add missing Distributed Systems TOC entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ This repository is a compilation of well-written, step-by-step guides for re-cre
 It's a great way to learn.
 
 * [3D Renderer](#build-your-own-3d-renderer)
-* [AI Model](#ai-model)
+* [AI Model](#build-your-own-ai-model)
 * [Augmented Reality](#build-your-own-augmented-reality)
 * [BitTorrent Client](#build-your-own-bittorrent-client)
 * [Blockchain / Cryptocurrency](#build-your-own-blockchain--cryptocurrency)
 * [Bot](#build-your-own-bot)
 * [Command-Line Tool](#build-your-own-command-line-tool)
+* [Distributed Systems](#build-your-own-distributed-systems)
 * [Database](#build-your-own-database)
 * [Docker](#build-your-own-docker)
 * [Emulator / Virtual Machine](#build-your-own-emulator--virtual-machine)


### PR DESCRIPTION
## Summary

This PR fixes two bugs in the Table of Contents of README.md.

### Bug 1: Broken anchor for "AI Model"

The TOC had:
```
* [AI Model](#ai-model)
```

But the actual section heading `#### Build your own \`AI Model\`` generates anchor `#build-your-own-ai-model`. The old link `#ai-model` was going nowhere.

**Fix:** Changed to `[AI Model](#build-your-own-ai-model)`

### Bug 2: "Distributed Systems" missing from TOC

The README contains a full section `#### Build your own \`Distributed Systems\`` with a tutorial entry, but it had **no entry in the Table of Contents**, making it undiscoverable via TOC navigation.

**Fix:** Added `* [Distributed Systems](#build-your-own-distributed-systems)` to the TOC.

Closes #1750

Signed-off-by: cocoon <54054995+kuishou68@users.noreply.github.com>