### PR TITLE
Add an AI Agent section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository is a compilation of well-written, step-by-step guides for re-cre
 It's a great way to learn.
 
 * [3D Renderer](#build-your-own-3d-renderer)
+* [AI Agent](#build-your-own-ai-agent)
 * [AI Model](#ai-model)
 * [Augmented Reality](#build-your-own-augmented-reality)
 * [BitTorrent Client](#build-your-own-bittorrent-client)
@@ -57,6 +58,12 @@ It's a great way to learn.
 * [**Java**: _How to create your own simple 3D render engine in pure Java_](http://blog.rogach.org/2015/08/how-to-create-your-own-simple-3d-render.html)
 * [**JavaScript / Pseudocode**: _Computer Graphics from scratch_](http://www.gabrielgambetta.com/computer-graphics-from-scratch/introduction.html)
 * [**Python**: _A 3D Modeller_](http://aosabook.org/en/500L/a-3d-modeller.html)
+
+#### Build your own `AI Agent`
+
+* [**Python**: _Building an AI agent from scratch in Python_](https://www.leoniemonigatti.com/blog/ai-agent-from-scratch-in-python.html)
+* [**Python**: _Build Your Own OpenClaw_](https://github.com/czl9707/build-your-own-openclaw)
+* [**TypeScript**: _Build Your Own AI Coding Agent From Scratch_](https://github.com/nauvalazhar/build-your-own-ai-coding-agent)
 
 #### Build your own `AI Model`
 * [**Python**: _A Large Language Model (LLM)_](https://github.com/rasbt/LLMs-from-scratch)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ It's a great way to learn.
 
 #### Build your own `AI Agent`
 
+* [**Go**: _How to Build an Agent_](https://ampcode.com/how-to-build-an-agent)
 * [**Python**: _Building an AI agent from scratch in Python_](https://www.leoniemonigatti.com/blog/ai-agent-from-scratch-in-python.html)
 * [**Python**: _Build Your Own OpenClaw_](https://github.com/czl9707/build-your-own-openclaw)
 * [**TypeScript**: _Build Your Own AI Coding Agent From Scratch_](https://github.com/nauvalazhar/build-your-own-ai-coding-agent)


### PR DESCRIPTION
## Summary
- add a dedicated `AI Agent` section to the README table of contents and tutorials list
- include four build-from-scratch resources across Go, Python, and TypeScript for agent workflows
- closes #1694

## Why
AI agents are now a distinct learning area with their own patterns around planning, tool use, and memory. Giving them a dedicated section makes these resources easier to discover instead of leaving them scattered across other categories.
