### PR TITLE
fix: correct TOC anchor links and add missing entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@ This repository is a compilation of well-written, step-by-step guides for re-cre
 It's a great way to learn.
 
 * [3D Renderer](#build-your-own-3d-renderer)
-* [AI Model](#ai-model)
+* [AI Model](#build-your-own-ai-model)
 * [Augmented Reality](#build-your-own-augmented-reality)
 * [BitTorrent Client](#build-your-own-bittorrent-client)
 * [Blockchain / Cryptocurrency](#build-your-own-blockchain--cryptocurrency)
 * [Bot](#build-your-own-bot)
 * [Command-Line Tool](#build-your-own-command-line-tool)
 * [Database](#build-your-own-database)
+* [Distributed Systems](#build-your-own-distributed-systems)
 * [Docker](#build-your-own-docker)
 * [Emulator / Virtual Machine](#build-your-own-emulator--virtual-machine)
 * [Front-end Framework / Library](#build-your-own-front-end-framework--library)


### PR DESCRIPTION
## Summary
This PR fixes two issues in the table of contents:

1. **Incorrect anchor link**: The "AI Model" TOC entry was pointing to `#ai-model` but the actual heading ID is `#build-your-own-ai-model`
2. **Missing TOC entry**: The "Distributed Systems" section exists in the document but was missing from the table of contents

## Changes
- Updated AI Model TOC link from `#ai-model` to `#build-your-own-ai-model`
- Added missing "Distributed Systems" entry to TOC (between Database and Docker)

Fixes #1750

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates README table-of-contents links; no code or runtime behavior is affected.
> 
> **Overview**
> Fixes the README table of contents by correcting the `AI Model` anchor to point to `#build-your-own-ai-model` and adding a missing `Distributed Systems` entry so the TOC matches the existing sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3679c90c1e03bf1ba6f6b97a46fc20bc6df5e81f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->