### PR TITLE
fix: correct broken TOC anchor for AI Model and add missing Distributed Systems entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@ This repository is a compilation of well-written, step-by-step guides for re-cre
 It's a great way to learn.
 
 * [3D Renderer](#build-your-own-3d-renderer)
-* [AI Model](#ai-model)
+* [AI Model](#build-your-own-ai-model)
 * [Augmented Reality](#build-your-own-augmented-reality)
 * [BitTorrent Client](#build-your-own-bittorrent-client)
 * [Blockchain / Cryptocurrency](#build-your-own-blockchain--cryptocurrency)
 * [Bot](#build-your-own-bot)
 * [Command-Line Tool](#build-your-own-command-line-tool)
 * [Database](#build-your-own-database)
+* [Distributed Systems](#build-your-own-distributed-systems)
 * [Docker](#build-your-own-docker)
 * [Emulator / Virtual Machine](#build-your-own-emulator--virtual-machine)
 * [Front-end Framework / Library](#build-your-own-front-end-framework--library)


### PR DESCRIPTION
## Summary

Fixes two TOC bugs reported in #1750:

**Bug 1 — Broken anchor for "AI Model"**
- `[AI Model](#ai-model)` → `[AI Model](#build-your-own-ai-model)`
- The section heading is `#### Build your own \`AI Model\`` which generates anchor `#build-your-own-ai-model`. The old `#ai-model` pointed nowhere.

**Bug 2 — "Distributed Systems" missing from TOC**
- Adds `* [Distributed Systems](#build-your-own-distributed-systems)` between `[Database]` and `[Docker]` (alphabetical order).
- The section `#### Build your own \`Distributed Systems\`` already exists in the content but had no TOC entry.

## Changes

- `README.md` — 2-line TOC fix

Closes #1750