### PR TITLE
fix: update broken JavaScript Roguelike tutorial URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ It's a great way to learn.
 * [**JavaScript**: _How to Make Flappy Bird in HTML5 With Phaser_](http://www.lessmilk.com/tutorial/flappy-bird-phaser-1)
 * [**JavaScript**: _Developing Games with React, Redux, and SVG_](https://auth0.com/blog/developing-games-with-react-redux-and-svg-part-1/)
 * [**JavaScript**: _Build your own 8-Ball Pool game from scratch_](https://www.youtube.com/watch?v=aXwCrtAo4Wc) [video]
-* [**JavaScript**: _How to Make Your First Roguelike_](https://gamedevelopment.tutsplus.com/tutorials/how-to-make-your-first-roguelike--gamedev-13677)
+* [**JavaScript**: _How to Make Your First Roguelike_](https://code.tutsplus.com/how-to-make-your-first-roguelike--gamedev-13677)
 * [**JavaScript**: _Think like a programmer: How to build Snake using only JavaScript, HTML & CSS_](https://medium.freecodecamp.org/think-like-a-programmer-how-to-build-snake-using-only-javascript-html-and-css-7b1479c3339e)
 * [**Lua**: _BYTEPATH_](https://github.com/SSYGEN/blog/issues/30)
 * [**Python**: _Developing Games With PyGame_](https://pythonprogramming.net/pygame-python-3-part-1-intro/)


### PR DESCRIPTION
## Summary

The `gamedevelopment.tutsplus.com` domain was rebranded/redirected to `code.tutsplus.com`. The old URL for the "How to Make Your First Roguelike" JavaScript tutorial is no longer accessible.

- **Old URL**: `https://gamedevelopment.tutsplus.com/tutorials/how-to-make-your-first-roguelike--gamedev-13677`
- **New URL**: `https://code.tutsplus.com/how-to-make-your-first-roguelike--gamedev-13677`

Fixes #1781

## Test plan

- [ ] Verify the updated URL resolves to the correct tutorial page