### PR TITLE
Update Hecto tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ It's a great way to learn.
 * [**Python**: _Python Tutorial: Make Your Own Text Editor_](https://www.youtube.com/watch?v=xqDonHEYPgA) [video]
 * [**Python**: _Create a Simple Python Text Editor!_](http://www.instructables.com/id/Create-a-Simple-Python-Text-Editor/)
 * [**Ruby**: _Build a Collaborative Text Editor Using Rails_](https://blog.aha.io/text-editor/)
-* [**Rust**: _Hecto: Build your own text editor in Rust_ ](https://www.flenker.blog/hecto/)
+* [**Rust**: _Hecto: Build your own text editor in Rust_ ](https://philippflenker.com/hecto/)
 
 #### Build your own `Visual Recognition System`
 


### PR DESCRIPTION
Fixes #1531.

Updates the Hecto text editor tutorial link to the current `philippflenker.com/hecto/` URL.

Validation:
- `curl -I -L --max-time 20 https://philippflenker.com/hecto/`
- `git diff --check`