### PR TITLE
Update CSS search engine resource title

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ It's a great way to learn.
 
 #### Build your own `Search Engine`
 
-* [**CSS**: _A search engine in CSS_](https://stories.algolia.com/a-search-engine-in-css-b5ec4e902e97)
+* [**CSS**: _How we built the real demo for our fake CSS API client_](https://www.algolia.com/blog/engineering/real-demo-fake-css-api-client)
 * [**Python**: _Building a search engine using Redis and redis-py_](http://www.dr-josiah.com/2010/07/building-search-engine-using-redis-and.html)
 * [**Python**: _Building a Vector Space Indexing Engine in Python_](https://boyter.org/2010/08/build-vector-space-search-engine-python/)
 * [**Python**: _Building A Python-Based Search Engine_](https://www.youtube.com/watch?v=cY7pE7vX6MU) [video]


### PR DESCRIPTION
This replaces the broken Algolia Stories link for `CSS: A search engine in CSS` with Algolia's current engineering article about the same CSS search demo.

The old `stories.algolia.com` URL is reported as broken in #1580. The new URL returns HTTP 200 and points to an official Algolia page.

Closes #1580.