### PR TITLE
fix: update dead 'How X Window Managers Work' link to author's live site

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ It's a great way to learn.
 * [**C**: _Write a System Call_](https://brennan.io/2016/11/14/kernel-dev-ep3/)
 * [**C**: _Sol - An MQTT broker from scratch_](https://codepr.github.io/posts/sol-mqtt-broker)
 * [**C++**: _Build your own VR headset for $200_](https://github.com/relativty/Relativ)
-* [**C++**: _How X Window Managers work and how to write one_](https://seasonofcode.com/posts/how-x-window-managers-work-and-how-to-write-one-part-i.html)
+* [**C++**: _How X Window Managers work and how to write one_](https://jichu4n.com/posts/how-x-window-managers-work-and-how-to-write-one-part-i/)
 * [**C++**: _Writing a Linux Debugger_](https://blog.tartanllama.xyz/writing-a-linux-debugger-setup/)
 * [**C++**: _How a 64k intro is made_](http://www.lofibucket.com/articles/64k_intro.html)
 * [**C++**: _Make your own Game Engine_](https://www.youtube.com/playlist?list=PLlrATfBNZ98dC-V-N3m0Go4deliWHPFwT)


### PR DESCRIPTION
## What

The **C++ – _How X Window Managers work and how to write one_** entry pointed at
`https://seasonofcode.com/posts/how-x-window-managers-work-and-how-to-write-one-part-i.html`,
which is no longer reachable (the `seasonofcode.com` domain is dead).

The author moved the article to their current site. This updates the link to the
live canonical URL:

`https://jichu4n.com/posts/how-x-window-managers-work-and-how-to-write-one-part-i/`

## Verification

- Old URL: dead (connection fails / redirects to a 404).
- New URL: returns HTTP 200. All three parts of the series are live on
  `jichu4n.com` (part-i, part-ii, part-iii) — same author, same content.

One-line change; no entries added or removed.
