### PR TITLE
Remove broken Rust CLI tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ It's a great way to learn.
 * [**Nim**: _Writing a stow alternative to manage dotfiles_](https://xmonader.github.io/nimdays/day06_nistow.html)
 * [**Node.js**: _Create a CLI tool in Javascript_](https://citw.dev/tutorial/create-your-own-cli-tool)
 * [**Rust**: _Command line apps in Rust_](https://rust-cli.github.io/book/index.html)
-* [**Rust**: _Writing a Command Line Tool in Rust_](https://mattgathu.dev/2017/08/29/writing-cli-app-rust.html)
 * [**Zig**: _Build Your Own CLI App in Zig from Scratch_](https://rebuild-x.github.io/docs/#/./zig/terminal/cli)
 
 


### PR DESCRIPTION
## Description

Removes the Rust CLI tutorial link reported in #1815 because the `mattgathu.dev` host no longer resolves.

Closes #1815.

## Verification

- Confirmed `curl -I -L https://mattgathu.dev/2017/08/29/writing-cli-app-rust.html` fails with `Could not resolve host: mattgathu.dev`.
- Confirmed the broken URL no longer appears in `README.md`.