### PR TITLE
Fix incorrect anchor link for "Build your own AI model"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository is a compilation of well-written, step-by-step guides for re-cre
 It's a great way to learn.
 
 * [3D Renderer](#build-your-own-3d-renderer)
-* [AI Model](#ai-model)
+* [AI Model](#build-your-own-ai-model)
 * [Augmented Reality](#build-your-own-augmented-reality)
 * [BitTorrent Client](#build-your-own-bittorrent-client)
 * [Blockchain / Cryptocurrency](#build-your-own-blockchain--cryptocurrency)


### PR DESCRIPTION
## Summary

This PR fixes an incorrect anchor link in the README.

The existing link points to `#ai-model`, but the actual GitHub-generated anchor for the section is `#build-your-own-ai-model`.

This updates the link so it correctly navigates to the "Build your own AI model" section.