### PR TITLE
add: OCaml/C++ "proper" programming language tutorial (Bolt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ It's a great way to learn.
 * [**JavaScript**: _Let’s go write a Lisp_](https://idiocy.org/lets-go-write-a-lisp/part-1.html)
 * [**OCaml**: _Writing a C Compiler_](https://norasandler.com/2017/11/29/Write-a-Compiler.html)
 * [**OCaml**: _Writing a Lisp, the series_](https://bernsteinbear.com/blog/lisp/)
+* [**OCaml / C++**: _How I wrote my own "proper" programming language_](https://mukulrathi.com/create-your-own-programming-language/intro-to-compiler/)
 * [**Pascal**: _Let's Build a Compiler_](https://compilers.iecc.com/crenshaw/)
 * [**Python**: _A Python Interpreter Written in Python_](http://aosabook.org/en/500L/a-python-interpreter-written-in-python.html)
 * [**Python**: _lisp.py: Make your own Lisp interpreter_](http://khamidou.com/compilers/lisp.py/)


### PR DESCRIPTION
Adds Mukul Rathi's multi-part series _How I wrote my own "proper" programming language_ (OCaml frontend + C++/LLVM backend) to the `Programming Language` section (issue #1760).

Why it fits the repo's bar: a guided, multi-part series that builds an entire language ("Bolt") end-to-end — real grammar → parser → native code via LLVM — not a glue-libraries write-up. The intro post links eleven follow-up posts covering parsing, type-checking, and codegen.

URL verified reachable (HTTP 200). Added after the existing OCaml entries, matching the `* [**OCaml / C++**: _Title_](url)` formatting convention.