### PR TITLE
add: Python search engine (inverted index + TF-IDF) tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ It's a great way to learn.
 * [**Python**: _Building a search engine using Redis and redis-py_](http://www.dr-josiah.com/2010/07/building-search-engine-using-redis-and.html)
 * [**Python**: _Building a Vector Space Indexing Engine in Python_](https://boyter.org/2010/08/build-vector-space-search-engine-python/)
 * [**Python**: _Building A Python-Based Search Engine_](https://www.youtube.com/watch?v=cY7pE7vX6MU) [video]
+* [**Python**: _Build Your Own Search Engine (inverted index + TF-IDF)_](https://github.com/Osamaali313/build-your-own-search-engine)
 * [**Python**: _Making text search learn from feedback_](https://medium.com/filament-ai/making-text-search-learn-from-feedback-4fe210fd87b0)
 * [**Python**: _Finding Important Words in Text Using TF-IDF_](https://stevenloria.com/tf-idf/)
 


### PR DESCRIPTION
Adds a from-scratch Python full-text search engine tutorial (inverted index + TF-IDF) to the `Search Engine` section (issue #1802).

Why it fits the repo's bar: built with the **Python standard library only** — no `nltk`, `whoosh`, `numpy`, or other third-party packages — so it teaches the internals rather than gluing libraries. Repo reachable (HTTP 200). Added after the existing Python Search Engine entries, matching formatting.