### PR TITLE
add: SmolML - a machine learning library from scratch (Python)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ It's a great way to learn.
 * [**Python**: _An Introduction to Convolutional Neural Networks_](https://victorzhou.com/blog/intro-to-cnns-part-1/)
 * [**Python**: _Neural Networks: Zero to Hero_](https://www.youtube.com/playlist?list=PLAqhIrjkxbuWI23v9cThsA9GvCAUhRvKZ)
 * [**Python**: _SlowTorch: Implementation of PyTorch from the ground up in 100% pure Python_](https://github.com/xames3/slowtorch)
+* [**Python**: _SmolML: A Machine Learning Library from Scratch_](https://github.com/rodmarkun/SmolML)
 
 #### Build your own `Operating System`
 


### PR DESCRIPTION
Adds SmolML — a machine learning library implemented from scratch in Python — to the `Neural Network` section (issue #1643, closes #1642).

Why it fits the repo's bar: a from-scratch implementation (no ML-framework glue), building core ML primitives by hand. Repo reachable (HTTP 200). Added after the existing Python Neural Network entries.