### PR TITLE
add: Rust-based git implementation (RIT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ It's a great way to learn.
 * [**Python**: _Write yourself a Git!_](https://wyag.thb.lt/)
 * [**Python**: _ugit: Learn Git Internals by Building Git Yourself_](https://www.leshenko.net/p/ugit/)
 * [**Ruby**: _Rebuilding Git in Ruby_](https://robots.thoughtbot.com/rebuilding-git-in-ruby)
+* [**Rust**: _RIT: A rust-based git implementation_](https://github.com/srs-sudeep/RIT)
 
 #### Build your own `Memory Allocator`
 


### PR DESCRIPTION
Adds RIT — a git implementation written from scratch in Rust — to the `Git` section (issue #1636).

Why it fits: a from-scratch reimplementation (not a wrapper around libgit2), teaching Git internals in Rust. Repo reachable (HTTP 200). Added after the existing Git entries.