### PR TITLE
add: C-Shell - a shell written from scratch in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ It's a great way to learn.
 * [**C**: _Writing a UNIX Shell_](https://indradhanush.github.io/blog/writing-a-unix-shell-part-1/)
 * [**C**: _Build Your Own Shell_](https://github.com/tokenrove/build-your-own-shell)
 * [**C**: Write a shell in C](https://danishpraka.sh/posts/write-a-shell/)
+* [**C**: _C-Shell: a shell written from scratch in C_](https://github.com/JeetMajumdar2003/C-Shell)
 * [**Go**: _Writing a simple shell in Go_](https://sj14.gitlab.io/post/2018-07-01-go-unix-shell/)
 * [**Rust**: _Build Your Own Shell using Rust_](https://www.joshmcguigan.com/blog/build-your-own-shell-rust/)
 


### PR DESCRIPTION
Adds the C-Shell repository — a shell implemented from scratch in C — to the `Shell` section (issue #1651).

Why it fits: ships a step-by-step `Build from Scratch` guide and architecture docs (`docs/BUILD_FROM_SCRATCH.md`, `docs/ARCHITECTURE.md`), plus tests, under MIT. Repo reachable (HTTP 200). Added at the end of the C-shell entries.