### PR TITLE
add: LearnDB - a simple database from scratch in Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ It's a great way to learn.
 * [**JavaScript**: _Dagoba: an in-memory graph database_](http://aosabook.org/en/500L/dagoba-an-in-memory-graph-database.html)
 * [**Python**: _DBDB: Dog Bed Database_](http://aosabook.org/en/500L/dbdb-dog-bed-database.html)
 * [**Python**: _Write your own miniature Redis with Python_](http://charlesleifer.com/blog/building-a-simple-redis-server-with-python/)
+* [**Python**: _LearnDB: build a simple database from scratch in Python_](https://github.com/spandanb/learndb-py)
 * [**Ruby**: _Build your own fast, persistent KV store in Ruby_](https://dineshgowda.com/posts/build-your-own-persistent-kv-store/)
 * [**Rust**: _Build your own Redis client and server_](https://tokio.rs/tokio/tutorial/setup)
 


### PR DESCRIPTION
Adds LearnDB — a database implemented from scratch in Python — to the `Database` section (issue #946).

Why it fits: a from-scratch DB tutorial (no ORM/framework glue), teaching storage internals in Python. Repo reachable (HTTP 200). Added after the existing Python Database entries.