### PR TITLE
add: Write your own Virtual Machine in 62 lines of Ada

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ It's a great way to learn.
 * [**JavaScript**: _GameBoy Emulation in JavaScript_](http://imrannazar.com/GameBoy-Emulation-in-JavaScript)
 * [**Python**: _Emulation Basics: Write your own Chip 8 Emulator/Interpreter_](http://omokute.blogspot.com.br/2012/06/emulation-basics-write-your-own-chip-8.html)
 * [**Rust**: _0dmg: Learning Rust by building a partial Game Boy emulator_](https://jeremybanks.github.io/0dmg/)
+* [**Ada**: _Write your own Virtual Machine in 62 lines of Ada_](https://harishtpj.github.io/posts/ada_vm/)
 
 #### Build your own `Front-end Framework / Library`
 


### PR DESCRIPTION
Adds a from-scratch virtual machine written in 62 lines of Ada to the `Emulator / Virtual Machine` section (issue #877).

Why it fits: a guided, framework-free from-scratch VM build (no libraries), in an unusual language for the section. Page reachable (HTTP 200). Added after the existing Emulator/VM entries.