### PR TITLE
add: To-Do CLI Application in C++

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ It's a great way to learn.
 * [**Rust**: _Command line apps in Rust_](https://rust-cli.github.io/book/index.html)
 * [**Rust**: _Writing a Command Line Tool in Rust_](https://mattgathu.dev/2017/08/29/writing-cli-app-rust.html)
 * [**Zig**: _Build Your Own CLI App in Zig from Scratch_](https://rebuild-x.github.io/docs/#/./zig/terminal/cli)
+* [**C++**: _To-Do CLI Application in C++_](https://github.com/Kei-K23/todo-cli)
 
 
 #### Build your own `Database`


### PR DESCRIPTION
Adds a from-scratch To-Do CLI application written in C++ to the `Command-Line Tool` section (issue #1133).

Why it fits: a built-from-scratch CLI tool (no framework glue), in C++. Repo reachable (HTTP 200). Added after the existing Command-Line Tool entries.