### PR TITLE
add: Operating System in 1000 Lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ It's a great way to learn.
 * [**Rust**: _Writing an OS in Rust_](https://os.phil-opp.com/)
 * [**Rust**: _Add RISC-V Rust Operating System Tutorial_](https://osblog.stephenmarz.com/)
 * [**(any)**: _Linux from scratch_](https://linuxfromscratch.org/lfs)
+* [**C**: _Operating System in 1000 Lines_](https://operating-system-in-1000-lines.vercel.app/en/)
 
 #### Build your own `Physics Engine`
 


### PR DESCRIPTION
Adds a from-scratch operating system built in ~1000 lines of C to the `Operating System` section (issue #1397).

Why it fits: a guided, framework-free OS build teaching the internals directly. The tutorial is written in C (verified by source inspection). Page reachable (HTTP 200). Added after the existing Operating System entries.