### PR TITLE
add: Game tutorials in C/SDL (parallelrealities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ It's a great way to learn.
 * [**Ruby**: _Ruby Snake_](https://www.diatomenterprises.com/gamedev-on-ruby-why-not/)
 * [**Rust**: _Adventures in Rust: A Basic 2D Game_](https://a5huynh.github.io/posts/2018/adventures-in-rust/)
 * [**Rust**: _Roguelike Tutorial in Rust + tcod_](https://tomassedovic.github.io/roguelike-tutorial/)
+* [**C**: _Game tutorials for a bunch of different genres (SDL)_](https://www.parallelrealities.co.uk/tutorials/)
 
 #### Build your own `Git`
 


### PR DESCRIPTION
Adds a collection of from-scratch game tutorials across multiple genres (C/SDL) to the `Game` section (issue #1378).

Why it fits: guided, from-scratch game builds (no engine glue for the core logic), in C/SDL. Site reachable (HTTP 200). Added at the end of the Game section, matching the C entries.