### PR TITLE
add: WebGPU anime character renderer (3D Renderer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ It's a great way to learn.
 * [**Java**: _How to create your own simple 3D render engine in pure Java_](http://blog.rogach.org/2015/08/how-to-create-your-own-simple-3d-render.html)
 * [**JavaScript / Pseudocode**: _Computer Graphics from scratch_](http://www.gabrielgambetta.com/computer-graphics-from-scratch/introduction.html)
 * [**Python**: _A 3D Modeller_](http://aosabook.org/en/500L/a-3d-modeller.html)
+* [**TypeScript / JavaScript**: _How to Render an Anime Character with WebGPU_](https://reze.one/tutorial)
 
 #### Build your own `AI Model`
 * [**Python**: _A Large Language Model (LLM)_](https://github.com/rasbt/LLMs-from-scratch)


### PR DESCRIPTION
Adds a from-scratch WebGPU renderer tutorial (anime character) to the `3D Renderer` section (issue #1653).

Why it fits: a guided, step-by-step from-scratch renderer — no framework glue, modern WebGPU. Page reachable (HTTP 200). Added after the existing 3D Renderer entries.