### PR TITLE
add: Build your own Tor hidden service (Web Server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ It's a great way to learn.
 * [**Python**: _Building a basic HTTP Server from scratch in Python_](http://joaoventura.net/blog/2017/python-webserver/)
 * [**Python**: _Implementing a RESTful Web API with Python & Flask_](http://blog.luisrei.com/articles/flaskrest.html)
 * [**Ruby**: _Building a simple websockets server from scratch in Ruby_](http://blog.honeybadger.io/building-a-simple-websockets-server-from-scratch-in-ruby/)
+* [**PHP**: _Build Your Own Tor Hidden Service_](https://github.com/Paul-HenryP/build-your-own-hidden-service)
 
 #### Uncategorized
 


### PR DESCRIPTION
Adds a from-scratch Tor hidden service tutorial (PHP) to the `Web Server` section (issue #1704).

Why it fits: a guided, library-light build of a hidden service — a server reachable over Tor — which belongs under Web Server (the submitter's 3D Renderer checkbox was a mis-tag). Repo reachable (HTTP 200). Added after the existing Web Server entries.