### PR TITLE
add: Verlet physics engine in JavaScript (Physics Engine)

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ It's a great way to learn.
 * [**JavaScript**: _How Physics Engines Work_](http://buildnewgames.com/gamephysics/)
 * [**JavaScript**: _Broad Phase Collision Detection Using Spatial Partitioning_](http://buildnewgames.com/broad-phase-collision-detection/)
 * [**JavaScript**: _Build a simple 2D physics engine for JavaScript games_](https://developer.ibm.com/tutorials/wa-build2dphysicsengine/?mhsrc=ibmsearch_a&mhq=2dphysic)
+* [**JavaScript**: _Making a Verlet Physics Engine in JavaScript_](https://anuraghazra.github.io/blog/making-a-verlet-physics-engine-in-javascript)
 
 #### Build your own `Processor`
 


### PR DESCRIPTION
Adds a from-scratch Verlet physics engine tutorial (JavaScript) to the `Physics Engine` section (issue #454).

Why it fits: a guided, library-free build of a real-time physics integrator — no engine glue. Page reachable (HTTP 200). Added after the existing JavaScript Physics Engine entries.