### PR TITLE
add: How to create a Matrix bot (Bot)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ It's a great way to learn.
 * [**Python**: _Creating Reddit Bot with Python & PRAW_](https://www.youtube.com/playlist?list=PLIFBTFgFpoJ9vmYYlfxRFV6U_XhG-4fpP) [video]
 * [**R**: _Build A Cryptocurrency Trading Bot with R_](https://towardsdatascience.com/build-a-cryptocurrency-trading-bot-with-r-1445c429e1b1)
 * [**Rust**: _A bot for Starcraft in Rust, C or any other language_](https://habr.com/en/post/436254/)
+* [**Go**: _How to Create a Matrix Bot_](https://www.reddit.com/r/matrixdotorg/comments/mdqitp/how_to_create_a_matrix_bot)
 
 #### Build your own `Command-Line Tool`
 


### PR DESCRIPTION
Adds a from-scratch Matrix bot tutorial (Go) to the `Bot` section (issue #607).

Why it fits: a guided build of a chat bot from scratch (no bot framework glue). The linked walkthrough uses Go. Page reachable (HTTP 200). Added after the existing Bot entries.