### PR TITLE
add: Build a Lua interpreter in Rust (Programming Language)

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ It's a great way to learn.
 * [**Ruby**: _A Compiler From Scratch_](https://www.destroyallsoftware.com/screencasts/catalog/a-compiler-from-scratch)
 * [**Ruby**: _Markdown compiler from scratch in Ruby_](https://blog.beezwax.net/2017/07/07/writing-a-markdown-compiler/)
 * [**Rust**: _Learning Parser Combinators With Rust_](https://bodil.lol/parser-combinators/)
+* [**Rust**: _Build a Lua Interpreter in Rust_](https://wubingzheng.github.io/build-lua-in-rust/en/)
 * [**Swift**: _Building a LISP from scratch with Swift_](https://www.uraimo.com/2017/02/05/building-a-lisp-from-scratch-with-swift/)
 * [**TypeScript**: _Build your own WebAssembly Compiler_](https://blog.scottlogic.com/2019/05/17/webassembly-compiler.html)
 


### PR DESCRIPTION
Adds a from-scratch Lua interpreter tutorial (Rust) to the `Programming Language` section (issue #920).

Why it fits: a guided, library-light build of a language interpreter from scratch. Page reachable (HTTP 200). Added after the existing Rust Programming Language entries.