### PR TITLE
add: Python C compiler to LLVM (ecco) (Programming Language)

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ It's a great way to learn.
 * [**Rust**: _Learning Parser Combinators With Rust_](https://bodil.lol/parser-combinators/)
 * [**Swift**: _Building a LISP from scratch with Swift_](https://www.uraimo.com/2017/02/05/building-a-lisp-from-scratch-with-swift/)
 * [**TypeScript**: _Build your own WebAssembly Compiler_](https://blog.scottlogic.com/2019/05/17/webassembly-compiler.html)
+* [**Python**: _Building an LLVM frontend for C from scratch (ecco)_](https://github.com/CharlesAverill/ecco)
 
 #### Build your own `Regex Engine`
 


### PR DESCRIPTION
Adds a from-scratch C compiler (Python → LLVM) tutorial to the `Programming Language` section (issue #882).

Why it fits: a guided, library-light compiler build — distinct from the existing C interprets-C entry. It re-implements DoctorWkt/acwj's approach in approachable Python and targets LLVM for safer/faster binaries. Repo reachable (HTTP 200). Added at the end of the Programming Language section.