### PR TITLE
add: Neural Network from scratch in C++, NN&DL, and Haskell NN

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,9 @@ It's a great way to learn.
 * [**Python**: _An Introduction to Convolutional Neural Networks_](https://victorzhou.com/blog/intro-to-cnns-part-1/)
 * [**Python**: _Neural Networks: Zero to Hero_](https://www.youtube.com/playlist?list=PLAqhIrjkxbuWI23v9cThsA9GvCAUhRvKZ)
 * [**Python**: _SlowTorch: Implementation of PyTorch from the ground up in 100% pure Python_](https://github.com/xames3/slowtorch)
+* [**C++**: _Neural Network from scratch in C++_](https://github.com/SorawitChok/Neural-Network-from-scratch-in-Cpp)
+* [**Various**: _Neural Networks and Deep Learning_](http://neuralnetworksanddeeplearning.com/)
+* [**Haskell**: _Practical Dependent Types in Haskell: Type-Safe Neural Networks (Part 1)_](https://blog.jle.im/entry/practical-dependent-types-in-haskell-1.html)
 
 #### Build your own `Operating System`
 


### PR DESCRIPTION
Adds three from-scratch Neural Network tutorials to the `Neural Network` section:

1. **C++** — Neural Network from scratch in C++ (issue #1170). Repo reachable (HTTP 200).
2. **Various** — Michael Nielsen's *Neural Networks and Deep Learning* (issue #866), the classic free book. Page reachable (HTTP 200).
3. **Haskell** — Practical Dependent Types in Haskell: Type-Safe Neural Networks (issue #781). Page reachable (HTTP 200).

All three are guided, library-light builds teaching NN internals. Added after the existing NN entries.