### PR TITLE
fix: add missing Distributed Systems entry to TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository is a compilation of well-written, step-by-step guides for re-cre
 It's a great way to learn.
 
 * [3D Renderer](#build-your-own-3d-renderer)
+* [Distributed Systems](#build-your-own-distributed-systems)
 * [AI Model](#build-your-own-ai-model)
 * [Augmented Reality](#build-your-own-augmented-reality)
 * [BitTorrent Client](#build-your-own-bittorrent-client)


### PR DESCRIPTION
Adds the missing **Distributed Systems** entry to the README table of contents (closes #1750, addresses #1755).

The `#### Build your own \`Distributed Systems\`` section exists in the body but was absent from the top TOC, so readers couldn't jump to it. The anchor `#build-your-own-distributed-systems` matches GitHub's slug for that heading exactly. Inserted in section order (after 3D Renderer, before AI Model).