### PR TITLE
add: minbpe (Karpathy GPT tokenizer) to AI Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ It's a great way to learn.
 * [**Python**: _A Large Language Model (LLM)_](https://github.com/rasbt/LLMs-from-scratch)
 * [**Python**: _Diffusion Models for Image Generation_](https://huggingface.co/learn/diffusion-course/en/unit1/3)
 * [**Python**: _RAG for Document Search_](https://github.com/langchain-ai/rag-from-scratch)
+* [**Python**: _Let's build the GPT Tokenizer_](https://github.com/karpathy/minbpe)
+
 
 #### Build your own `Augmented Reality`
 


### PR DESCRIPTION
Adds a curated tutorial entry per issue request.

Closes #1765 (tokenizer half; RAG substring overlaps existing langchain entry, left to avoid dup).

Entry follows the README `* *[Lang]* _Title_` convention and is inserted at the end of the appropriate section. Link verified reachable. Maintainer can modify.