### PR TITLE
add: yaccgo (Build your Own yacc, Go) to Programming Language

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,8 @@ It's a great way to learn.
 * [**Rust**: _Learning Parser Combinators With Rust_](https://bodil.lol/parser-combinators/)
 * [**Swift**: _Building a LISP from scratch with Swift_](https://www.uraimo.com/2017/02/05/building-a-lisp-from-scratch-with-swift/)
 * [**TypeScript**: _Build your own WebAssembly Compiler_](https://blog.scottlogic.com/2019/05/17/webassembly-compiler.html)
+* [**Go**: _Build your Own yacc_](https://github.com/acekingke/yaccgo)
+
 
 #### Build your own `Regex Engine`
 


### PR DESCRIPTION
Adds a curated tutorial entry per issue request.

Closes #685.

Entry follows the README `* *[Lang]* _Title_` convention and is inserted at the end of the appropriate section. Link verified reachable. Maintainer can modify.