### PR TITLE
add: Hobby OS in Rust to Operating System

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ It's a great way to learn.
 * [**Rust**: _Writing an OS in Rust_](https://os.phil-opp.com/)
 * [**Rust**: _Add RISC-V Rust Operating System Tutorial_](https://osblog.stephenmarz.com/)
 * [**(any)**: _Linux from scratch_](https://linuxfromscratch.org/lfs)
+* [**Rust**: _Hobby operating system in Rust_](https://intermezzos.github.io/)
 
 #### Build your own `Physics Engine`
 


### PR DESCRIPTION
Adds a curated tutorial entry per issue request.

Closes #391.

Entry follows the README `* *[Lang]* _Title_` convention and is appended at the end of the appropriate section. Link verified reachable. Maintainer can modify.