### PR TITLE
add: Raytracer in Rust to 3D Renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ It's a great way to learn.
 * [**Java**: _How to create your own simple 3D render engine in pure Java_](http://blog.rogach.org/2015/08/how-to-create-your-own-simple-3d-render.html)
 * [**JavaScript / Pseudocode**: _Computer Graphics from scratch_](http://www.gabrielgambetta.com/computer-graphics-from-scratch/introduction.html)
 * [**Python**: _A 3D Modeller_](http://aosabook.org/en/500L/a-3d-modeller.html)
+* [**Rust**: _Writing a Raytracer in Rust_](https://bheisler.github.io/post/writing-raytracer-in-rust-part-1/)
 
 #### Build your own `AI Model`
 * [**Python**: _A Large Language Model (LLM)_](https://github.com/rasbt/LLMs-from-scratch)


### PR DESCRIPTION
Adds a curated tutorial entry per issue request.

Closes #332.

Entry follows the README `* *[Lang]* _Title_` convention and is appended at the end of the appropriate section. Link verified reachable. Maintainer can modify.