### PR TITLE
add: Brainfuck compiler (JS) to Programming Language

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ It's a great way to learn.
 * [**Rust**: _Learning Parser Combinators With Rust_](https://bodil.lol/parser-combinators/)
 * [**Swift**: _Building a LISP from scratch with Swift_](https://www.uraimo.com/2017/02/05/building-a-lisp-from-scratch-with-swift/)
 * [**TypeScript**: _Build your own WebAssembly Compiler_](https://blog.scottlogic.com/2019/05/17/webassembly-compiler.html)
+* [**JavaScript**: _Let's Write a Brainfuck Compiler_](https://www.jsmonday.dev/articles/37/let-s-write-a-brainfuck-compiler)
 
 #### Build your own `Regex Engine`
 


### PR DESCRIPTION
Adds a curated tutorial entry per issue request.

Closes #377.

Entry follows the README `* *[Lang]* _Title_` convention and is appended at the end of the appropriate section. Link verified reachable. Maintainer can modify.