### PR TITLE
add: Toy JVM in Go to Emulator / Virtual Machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ It's a great way to learn.
 * [**JavaScript**: _GameBoy Emulation in JavaScript_](http://imrannazar.com/GameBoy-Emulation-in-JavaScript)
 * [**Python**: _Emulation Basics: Write your own Chip 8 Emulator/Interpreter_](http://omokute.blogspot.com.br/2012/06/emulation-basics-write-your-own-chip-8.html)
 * [**Rust**: _0dmg: Learning Rust by building a partial Game Boy emulator_](https://jeremybanks.github.io/0dmg/)
+* [**Go**: _Writing a toy JVM in Go_](https://zserge.com/posts/jvm/)
 
 #### Build your own `Front-end Framework / Library`
 


### PR DESCRIPTION
Adds a curated tutorial entry per issue request.

Closes #485.

Entry follows the README `* *[Lang]* _Title_` convention and is appended at the end of the appropriate section. Link verified reachable. Maintainer can modify.