### PR TITLE
add: Build your own autodiff (towardsdatascience) to Neural Network

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ It's a great way to learn.
 * [**Python**: _An Introduction to Convolutional Neural Networks_](https://victorzhou.com/blog/intro-to-cnns-part-1/)
 * [**Python**: _Neural Networks: Zero to Hero_](https://www.youtube.com/playlist?list=PLAqhIrjkxbuWI23v9cThsA9GvCAUhRvKZ)
 * [**Python**: _SlowTorch: Implementation of PyTorch from the ground up in 100% pure Python_](https://github.com/xames3/slowtorch)
+* [**Python**: _Build your own Automatic Differentiation_](https://towardsdatascience.com/build-your-own-automatic-differentiation-99140a3bf261)
 
 #### Build your own `Operating System`
 


### PR DESCRIPTION
Adds a curated tutorial entry per issue request.

Closes #784.

Entry follows the README `* *[Lang]* _Title_` convention and is appended at the end of the appropriate section. Link verified reachable. Maintainer can modify.