### PR TITLE
add: Learn Go by building a CLI tool to Command-Line Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ It's a great way to learn.
 * [**Rust**: _Command line apps in Rust_](https://rust-cli.github.io/book/index.html)
 * [**Rust**: _Writing a Command Line Tool in Rust_](https://mattgathu.dev/2017/08/29/writing-cli-app-rust.html)
 * [**Zig**: _Build Your Own CLI App in Zig from Scratch_](https://rebuild-x.github.io/docs/#/./zig/terminal/cli)
+* [**Go**: _Learn Go by building a command line tool_](https://levelup.gitconnected.com/learn-go-by-building-command-line-interfaces-with-go-4d845867be3f)
 
 
 #### Build your own `Database`


### PR DESCRIPTION
Adds a curated tutorial entry per issue request.

Closes #1022.

Entry follows the README `* *[Lang]* _Title_` convention and is appended at the end of the appropriate section. Link verified reachable. Maintainer can modify.