### PR TITLE
add: NestJS custom transporters intro to Uncategorized

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@ It's a great way to learn.
 * [**Rust**: _Writing Scalable Chat Service from Scratch_](https://nbaksalyar.github.io/2015/07/10/writing-chat-in-rust.html)
 * [**Rust**: _WebGL + Rust: Basic Water Tutorial_](https://www.chinedufn.com/3d-webgl-basic-water-tutorial/)
 * [**TypeScript**: _Tiny Package Manager: Learns how npm or Yarn works_](https://github.com/g-plane/tiny-package-manager)
+* [**TypeScript**: _NestJS custom transporters: introduction and setup_](https://dev.to/nestjs/part-1-introduction-and-setup-1a2l)
 
 ## Contribute 
 * Submissions welcome, just send a PR, or [create an issue](https://github.com/codecrafters-io/build-your-own-x/issues/new)


### PR DESCRIPTION
Adds a curated tutorial entry per issue request.

Closes #539.

Entry follows the README `* *[Lang]* _Title_` convention and is appended at the end of the appropriate section. Link verified reachable. Maintainer can modify.