### PR TITLE
add: Slack Bot tutorial (Python) to Bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ It's a great way to learn.
 * [**Python**: _Creating Reddit Bot with Python & PRAW_](https://www.youtube.com/playlist?list=PLIFBTFgFpoJ9vmYYlfxRFV6U_XhG-4fpP) [video]
 * [**R**: _Build A Cryptocurrency Trading Bot with R_](https://towardsdatascience.com/build-a-cryptocurrency-trading-bot-with-r-1445c429e1b1)
 * [**Rust**: _A bot for Starcraft in Rust, C or any other language_](https://habr.com/en/post/436254/)
+* [**Python**: _Build a Slack Bot tutorial_](https://github.com/slackapi/python-slackclient/tree/main/tutorial)
 
 #### Build your own `Command-Line Tool`
 


### PR DESCRIPTION
Adds a curated tutorial entry per issue request.

Closes #527.

Entry follows the README `* *[Lang]* _Title_` convention and is appended at the end of the appropriate section. Link verified reachable. Maintainer can modify.