### PR TITLE
add: Weather CLI app in Dart to Command-Line Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ It's a great way to learn.
 * [**Rust**: _Command line apps in Rust_](https://rust-cli.github.io/book/index.html)
 * [**Rust**: _Writing a Command Line Tool in Rust_](https://mattgathu.dev/2017/08/29/writing-cli-app-rust.html)
 * [**Zig**: _Build Your Own CLI App in Zig from Scratch_](https://rebuild-x.github.io/docs/#/./zig/terminal/cli)
+* [**Dart**: _Weather command-line app in Dart_](https://meamka.me/posts/make-a-weather-app-with-dart/)
 
 
 #### Build your own `Database`


### PR DESCRIPTION
Adds a curated tutorial entry per issue request.

Closes #1295.

Entry follows the README `* *[Lang]* _Title_` convention and is appended at the end of the appropriate section. Link verified reachable. Maintainer can modify.